### PR TITLE
Support multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Say one writes a script (`foo_my_bar.rb`), with a corresponding (`$HOME/.foo_my_
 
     some_relative_file_path=foo
     some_absolute_file_path=/path/to/bar
+    multiple_paths=foo:/path/to/bar
     my_password=uTxllKRD2S+IH92oi30luwu0JIqp7kKA
 
     [a_group]
@@ -79,6 +80,7 @@ This is the workflow and functionality offered by `SS::C`:
     configuration.some_relative_file_path.full_path # '$HOME/foo'
     configuration.some_absolute_file_path           # '/path/to/bar'
     configuration.some_absolute_file_path.full_path # '/path/to/bar' (recognized as absolute)
+    configuration.multiple_paths.full_paths         # ['$HOME/foo', '/path/to/bar']
 
     configuration.my_password.decrypted             # 'encrypted_value'
 

--- a/lib/simple_scripting/configuration/value.rb
+++ b/lib/simple_scripting/configuration/value.rb
@@ -24,6 +24,10 @@ module SimpleScripting
         start_with?('/') ? self : File.expand_path(self, '~')
       end
 
+      def full_paths
+        split(':').map { |value| self.class.new(value).full_path }
+      end
+
       def decrypted
         raise "Encryption key not provided!" if @encryption_key.nil?
 

--- a/lib/simple_scripting/version.rb
+++ b/lib/simple_scripting/version.rb
@@ -1,5 +1,5 @@
 module SimpleScripting
 
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 
 end

--- a/spec/simple_scripting/configuration_spec.rb
+++ b/spec/simple_scripting/configuration_spec.rb
@@ -23,6 +23,7 @@ describe SimpleScripting::Configuration do
   let(:configuration_text) {"
 abspath_key=/tmp/bar
 relpath_key=foo
+mixed_multiple_paths_key=/tmp/bar:foo
 encr_key=uTxllKRD2S+IH92oi30luwu0JIqp7kKA
 
 [group1]
@@ -39,6 +40,8 @@ g2_key=bang
       expect(configuration.abspath_key.full_path).to eql('/tmp/bar')
 
       expect(configuration.relpath_key.full_path).to eql(File.expand_path('foo', '~'))
+
+      expect(configuration.mixed_multiple_paths_key.full_paths).to eql(['/tmp/bar', File.expand_path('foo', '~')])
 
       expect(configuration.encr_key.decrypted).to eql('encrypted_value')
 


### PR DESCRIPTION
Support multiple paths, eg.:

    # configuration entry
    multiple_paths=foo:/path/to/bar
    # decoding
    configuration.multiple_paths.full_paths         # ['$HOME/foo', '/path/to/bar']

Solves #7.