### PR TITLE
Add TabCompletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 # SimpleScripting
 
-`SS` is a library composed of three modules (`TabCompletion`, `Argv` and `Configuration`) which simplify three common scripting tasks:
+`SimpleScripting` is a library composed of three modules (`TabCompletion`, `Argv` and `Configuration`) that simplify three common scripting tasks:
 
 - writing autocompletion scripts
 - implementing the commandline options parsing (and the related help)
 - loading and decoding the configuration for the script/application
 
-`SS` is an interesting (and useful) exercise in design, aimed at finding the simplest and most expressive data/structures which accomplish the given task(s). For this reason, the library can be useful for people who frequently write small scripts (eg. devops or nerds).
+`SimpleScripting` is an interesting (and useful) exercise in design, aimed at finding the simplest and most expressive data/structures that accomplish the given task(s). For this reason, the library can be useful for people who frequently write small scripts (eg. devops or nerds).
 
 ## SimpleScripting::TabCompletion
 
@@ -87,7 +87,7 @@ For a description of the more complex use cases, including edge cases and error 
 
 ## SimpleScripting::Argv
 
-`SS::A` is a module which acts as frontend to the standard Option Parser library (`optparse`), giving a very convenient format for specifying the arguments. `SS::A` also generates the help.
+`Argv` is a module which acts as frontend to the standard Option Parser library (`optparse`), giving a very convenient format for specifying the arguments. `Argv` also generates the help.
 
 This is a definition example:
 
@@ -148,7 +148,7 @@ For the guide, see the [wiki page](https://github.com/saveriomiroddi/simple_scri
 
 ## SimpleScripting::Configuration
 
-`SS::C` is a module which acts as frontend to the ParseConfig gem (`parseconfig`), giving compact access to the configuration and its values, and adding a few helpers for common tasks.
+`Configuration` is a module which acts as frontend to the ParseConfig gem (`parseconfig`), giving compact access to the configuration and its values, and adding a few helpers for common tasks.
 
 Say one writes a script (`foo_my_bar.rb`), with a corresponding (`$HOME/.foo_my_bar`) configuration, which contains:
 
@@ -160,7 +160,7 @@ Say one writes a script (`foo_my_bar.rb`), with a corresponding (`$HOME/.foo_my_
     [a_group]
     group_key=baz
 
-This is the workflow and functionality offered by `SS::C`:
+This is the workflow and functionality offered by `Configuration`:
 
     require 'simple_scripting/configuration'
 

--- a/README.md
+++ b/README.md
@@ -5,14 +5,85 @@
 
 # SimpleScripting
 
-*The TabCompletion component is under development; please check this project again on (or before) Sat 21/Jul/2018.*
+`SS` is a library composed of three modules (`TabCompletion`, `Argv` and `Configuration`) which simplify three common scripting tasks:
 
-`SS` is a library composed of two modules (`Argv` and `Configuration`) which simplify two common scripting tasks:
-
+- writing autocompletion scripts
 - implementing the commandline options parsing (and the related help)
 - loading and decoding the configuration for the script/application
 
 `SS` is an interesting (and useful) exercise in design, aimed at finding the simplest and most expressive data/structures which accomplish the given task(s). For this reason, the library can be useful for people who frequently write small scripts (eg. devops or nerds).
+
+## SimpleScripting::TabCompletion
+
+`TabCompletion` makes trivial to define tab-completion for terminal commands on Linux/Mac systems; it's so easy that an example is much simpler than an explanation.
+
+### Example
+
+Suppose we have the command:
+
+```sh
+open_project [-e|--with-editor EDITOR] <project_name>
+```
+
+We want to add tab completion both for the option and the project name. Easy!!
+
+Install the gem (`simple_scripting`), then create this class (`/my/completion_scripts/open_project_completion.rb`):
+
+```ruby
+#!/usr/bin/env ruby
+
+require 'simple_scripting/tab_completion'
+
+class OpenProjectTabCompletion
+  SYSTEM_EDITORS = `update-alternatives --list editor`.split("\n").map { |filename| File.basename(filename) }
+
+  def with_editor(prefix, suffix, context)
+    SYSTEM_EDITORS.grep /^#{prefix}/
+  end
+
+  def project_name(prefix, suffix, context)
+    Dir["/my/home/my_projects/#{prefix}*"]
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  completion_definition = [
+    ["-e", "--with-editor EDITOR"],
+    'project_name'
+  ]
+
+  SimpleScripting::TabCompletion.new(completion_definition).complete(OpenProjectTabCompletion.new)
+end
+```
+
+then chmod and register it:
+
+```sh
+$ chmod +x /my/completion_scripts/open_project_completion.rb
+$ complete -C /my/completion_scripts/open_project_completion.rb -o default open_project
+```
+
+Done!
+
+Now type the following, and get:
+
+```sh
+$ open_project g<tab>           # lists: "geet", "gitlab-ce", "gnome-terminal"
+$ open_project --with-editor v  # lists: "vim.basic", "vim.tiny"
+$ open_project --wi<tab>        # autocompletes "--with-editor"; this is built-in!
+```
+
+Happy completion!
+
+### Supported shells
+
+TabCompletion supports Bash, and Zsh with bashcompinit.
+
+Note that a recent version of Zsh is required - the Ubuntu 16.04 standard version has a bug that breaks bash-compatible completion.
+
+### More complex use cases
+
+For a description of the more complex use cases, including edge cases and error handling, see the [wiki](https://github.com/saveriomiroddi/simple_scripting/wiki/SimpleScripting::TabCompletion-Guide).
 
 ## SimpleScripting::Argv
 

--- a/lib/simple_scripting/tab_completion.rb
+++ b/lib/simple_scripting/tab_completion.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative 'tab_completion/commandline_processor'
+
+module SimpleScripting
+
+  # The naming of each of the the commandline units is not standard, therefore we establish the
+  # following arbitrary, but consistent, naming:
+  #
+  #     executable --option option_parameter argument
+  #
+  # The commandline is divided into words, as Bash would split them. All the words, except the
+  # executable, compose an array that we call `argv` (as Ruby would do).
+  #
+  # We define each {option name => value} or {argument name => value} as `pair`.
+  #
+  # In the context of a pair, each pair is composed of a `key` and a `value`.
+  #
+  class TabCompletion
+
+    def initialize(switches_definition, output: $stdout)
+      @switches_definition = switches_definition
+      @output = output
+    end
+
+    # Currently, any completion suffix is ignored and stripped.
+    #
+    def complete(execution_target, source_commandline=ENV.fetch('COMP_LINE'), cursor_position=ENV.fetch('COMP_POINT').to_i)
+      commandline_processor = CommandlineProcessor.process_commandline(source_commandline, cursor_position, @switches_definition)
+
+      if commandline_processor.completing_an_option?
+        complete_option(commandline_processor, execution_target)
+      elsif commandline_processor.parsing_error?
+        return
+      else # completing_a_value?
+        complete_value(commandline_processor, execution_target)
+      end
+    end
+
+    private
+
+    #############################################
+    # Completion!
+    #############################################
+
+    def complete_option(commandline_processor, execution_target)
+      all_switches = @switches_definition.select { |definition| definition.is_a?(Array) }.map { |definition| definition[1][/^--\S+/] }
+
+      matching_switches = all_switches.select { |switch| switch.start_with?(commandline_processor.completing_word_prefix) }
+
+      output_entries(matching_switches)
+    end
+
+    def complete_value(commandline_processor, execution_target)
+      key, value_prefix, value_suffix, other_pairs = commandline_processor.parsed_pairs
+
+      selected_entries = execution_target.send(key, value_prefix, value_suffix, other_pairs)
+
+      output_entries(selected_entries)
+    end
+
+    #############################################
+    # Helpers
+    #############################################
+
+    def output_entries(entries)
+      @output.print entries.join("\n")
+    end
+  end
+
+end

--- a/lib/simple_scripting/tab_completion/commandline_processor.rb
+++ b/lib/simple_scripting/tab_completion/commandline_processor.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+
+require_relative '../argv'
+
+module SimpleScripting
+
+  class TabCompletion
+
+    class CommandlineProcessor < Struct.new(:processed_argv, :cursor_marker, :switches_definition)
+
+      # Arbitrary; can be anything (except an empty string).
+      BASE_CURSOR_MARKER = "<tab>"
+
+      OPTIONS_TERMINATOR = "--"
+      LONG_OPTIONS_PREFIX = "--"
+
+      def self.process_commandline(source_commandline, cursor_position, switches_definition)
+        # An input string with infinite "<tabN>" substrings will cause an infinite cycle (hehe).
+        0.upto(Float::INFINITY) do |i|
+          cursor_marker = BASE_CURSOR_MARKER.sub(">", "#{i}>")
+
+          if !source_commandline.include?(cursor_marker)
+            commandline_with_marker = source_commandline[0...cursor_position] + cursor_marker + source_commandline[cursor_position..-1].to_s
+
+            # Remove the executable.
+            processed_argv = Shellwords.split(commandline_with_marker)[1..-1]
+
+            return new(processed_argv, cursor_marker, switches_definition)
+          end
+        end
+      end
+
+      # We're abstracted from the commandline, with this exception. This is because while an option
+      # is being completed, the decoder would not recognize the key.
+      #
+      def completing_an_option?
+        processed_argv[marked_word_position].start_with?(LONG_OPTIONS_PREFIX) && marked_word_position < options_terminator_position
+      end
+
+      def parsing_error?
+        parse_argv.nil?
+      end
+
+      def completing_word_prefix
+        word = processed_argv[marked_word_position]
+
+        # Regex alternative: [/\A(.*?)#{cursor_marker}/m, 1]
+        word[0, word.index(cursor_marker)]
+      end
+
+      # Returns key, value prefix (before marker), value suffix (after marker), other_pairs
+      #
+      def parsed_pairs
+        parsed_pairs = parse_argv || raise("Parsing error")
+
+        key, value = parsed_pairs.detect do |_, value|
+          !boolean?(value) && value.include?(cursor_marker)
+        end
+
+        # Impossible case, unless there is a programmatic error.
+        #
+        key || raise("Guru meditation! (#{self.class}##{__method__}:#{__LINE__})")
+
+        value_prefix, value_suffix = value.split(cursor_marker)
+
+        parsed_pairs.delete(key)
+
+        [key, value_prefix || "", value_suffix || "", parsed_pairs]
+      end
+
+      private
+
+      def marked_word_position
+        processed_argv.index { |word| word.include?(cursor_marker) }
+      end
+
+      # Returns Float::INFINITY when there is no options terminator.
+      #
+      def options_terminator_position
+        processed_argv.index(OPTIONS_TERMINATOR) || Float::INFINITY
+      end
+
+      #############################################
+      # Helpers
+      #############################################
+
+      def parse_argv
+        # We need to convert all the arguments to optional, otherwise it's not possible to
+        # autocomplete arguments when not all the mandatory ones are not typed yet, eg:
+        #
+        #   `my_command <tab>` with definition ['mand1', 'mand2']
+        #
+        adapted_switches_definition = switches_definition.dup
+
+        adapted_switches_definition.each_with_index do |definition, i|
+          adapted_switches_definition[i] = "[#{definition}]" if definition.is_a?(String) && !definition.start_with?('[')
+        end
+
+        SimpleScripting::Argv.decode(*adapted_switches_definition, arguments: processed_argv.dup, auto_help: false)
+      rescue Argv::InvalidCommand, Argv::ArgumentError, OptionParser::InvalidOption
+        # OptionParser::InvalidOption: see case "-O<tab>" in test suite.
+
+        # return nil
+      end
+
+      # For the lulz.
+      #
+      def boolean?(value)
+        !!value == value
+      end
+
+    end # CommandlineProcessor
+
+  end # TabCompletion
+
+end # SimpleScripting

--- a/spec/helpers/tab_completion_custom_rspec_matchers.rb
+++ b/spec/helpers/tab_completion_custom_rspec_matchers.rb
@@ -1,0 +1,55 @@
+require 'stringio'
+
+# Custom matchers for the tab completion test suite.
+#
+# Require :subject and :output_buffer to be defined/accessible.
+#
+# The matchers are simplistic (but still adequate); the (most) appropriate choice would be
+# [diffable matchers](https://relishapp.com/rspec/rspec-expectations/v/3-6/docs/custom-matchers/define-diffable-matcher)
+#
+# Note that the semantic of the expected value is different from the standard rspec one, since we
+# process it, therefore, we need to use intermediate instance variables.
+#
+module TabCompletionCustomRSpecMatchers
+
+  extend RSpec::Matchers::DSL
+
+  # Doesn't matter in this context.
+  #
+  PHONY_EXECUTABLE = '/path/to/executable'
+
+  matcher :complete_with do |expected_entries|
+    match do |symbolic_commandline_options|
+      commandline = "#{PHONY_EXECUTABLE} #{symbolic_commandline_options}"
+      cursor_position = commandline.index("<tab>")
+      commandline = commandline.sub("<tab>", "")
+
+      subject.complete(execution_target, commandline, cursor_position)
+
+      @actual_output = output_buffer.string
+      expected_output = expected_entries.join("\n")
+
+      expect(@actual_output).to eql(expected_output)
+    end
+
+    failure_message do |actual|
+      actual_entries = @actual_output.split("\n")
+
+      "#{actual} listed #{actual_entries} instead of #{expected}"
+    end
+  end
+
+  matcher :not_complete do
+    match do |symbolic_commandline_options|
+      expect(symbolic_commandline_options).to complete_with([])
+    end
+
+    failure_message do |actual|
+      @actual_output = output_buffer.string
+      actual_entries = @actual_output.split("\n")
+
+      "#{actual} listed #{actual_entries} instead of no entries"
+    end
+  end
+
+end # TabCompletionCustomRSpecMatchers

--- a/spec/simple_scripting/tab_completion_spec.rb
+++ b/spec/simple_scripting/tab_completion_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/simple_scripting/tab_completion.rb'
+
+describe SimpleScripting::TabCompletion do
+
+  include TabCompletionCustomRSpecMatchers
+
+  let(:output_buffer) {
+    StringIO.new
+  }
+
+  let(:switches_definition) {
+    [
+      ["-o", "--opt1 ARG"],
+      ["-O", "--opt2"],
+      "arg1",               # this and the following are internally converted to optional, as
+      "arg2",               # according to the Argv spec, without brackets they are mandatory.
+    ]
+  }
+
+  let(:execution_target) {
+    # Simplistic implementation. In real world, regex are not to be used this way, for multiple
+    # reasons.
+    #
+    Class.new do
+      def opt1(prefix, suffix, context)
+        %w(opt1v1 _opt1v2).select { |entry| entry =~ /^#{prefix}#{suffix}/ }
+      end
+
+      def arg1(prefix, suffix, context)
+        # A value starting with space is valid.
+        #
+        ['arg1v1', 'arg1v2', '_arg1v3', ' _argv1spc'].select { |entry| entry =~ /^#{prefix}#{suffix}/ }
+      end
+
+      def arg2(prefix, suffix, context)
+        # A value starting with minus is valid.
+        #
+        %w(arg2v1 arg2v2 --arg2v3).select { |entry| entry =~ /^#{prefix}#{suffix}/ }
+      end
+    end.new
+  }
+
+  subject { described_class.new(switches_definition, output: output_buffer) }
+
+  context "with a correct configuration" do
+
+    context "standard cases" do
+
+      # Note that the conversion of mandatory to optional argument is defined by most of the cases.
+      #
+      STANDARD_CASES = {
+        "<tab>"             => ["arg1v1", "arg1v2", "_arg1v3", " _argv1spc"],
+        "a<tab>"            => %w(arg1v1 arg1v2),
+        "--opt2 <tab>"      => ["arg1v1", "arg1v2", "_arg1v3", " _argv1spc"],
+        "-- <tab>"          => ["arg1v1", "arg1v2", "_arg1v3", " _argv1spc"],
+
+        "a <tab>"           => %w(arg2v1 arg2v2 --arg2v3),
+        "a -- --<tab>"      => %w(--arg2v3),
+        "-- --aaa <tab>"    => %w(arg2v1 arg2v2 --arg2v3),
+
+        "--<tab>"           => %w(--opt1 --opt2),
+        "--<tab> a"         => %w(--opt1 --opt2),
+        "--<tab> -- a"      => %w(--opt1 --opt2),
+        "--<tab> -- b"      => %w(--opt1 --opt2),
+        "--<tab> --xyz"     => %w(--opt1 --opt2),
+        "--opt1 <tab> a"    => %w(opt1v1 _opt1v2),
+        "--opt1 o<tab> a"   => %w(opt1v1),
+
+        "-o<tab>"           => %w(opt1v1 _opt1v2),
+        "-o <tab>"          => %w(opt1v1 _opt1v2),
+        "-o -O <tab>"       => ["arg1v1", "arg1v2", "_arg1v3", " _argv1spc"],
+        "-O <tab>"          => ["arg1v1", "arg1v2", "_arg1v3", " _argv1spc"],
+      }
+
+      STANDARD_CASES.each do |symbolic_commandline_options, expected_entries|
+        it "should output the entries for #{symbolic_commandline_options.inspect}" do
+          expect(symbolic_commandline_options).to complete_with(expected_entries)
+        end
+      end
+
+    end # context "standard cases"
+
+    context "suffix management" do
+
+      SUFFIX_CASES = {
+        "arg1<tab>v"        => %w(arg1v1 arg1v2), # the execution target of the test suite doesn't
+        "arg1<tab>x"        => %w(),              # ignore the suffix; programmer-defined
+
+        "--o<tab>p"         => %w(--opt1 --opt2), # options ignore the suffix (like bash); can't be
+        "--o<tab>x"         => %w(--opt1 --opt2), # currently changed by the programmer.
+      }
+
+      SUFFIX_CASES.each do |symbolic_commandline_options, expected_entries|
+        it "should output the entries for #{symbolic_commandline_options.inspect}, ignoring the suffix" do
+          expect(symbolic_commandline_options).to complete_with(expected_entries)
+        end
+      end
+
+    end # context "suffix management"
+
+    context "escaped cases" do
+
+      ESCAPED_CASES = {
+        "\ <tab>"           => [" _argv1spc"],
+        '\-<tab>'           => %w(),                       # this is the result of typing `command "\-<tab>`
+        'a \-<tab>'         => %w(--arg2v3),
+      }
+
+      ESCAPED_CASES.each do |symbolic_commandline_options, _|
+        it "should output the entries for #{symbolic_commandline_options.inspect}"
+      end
+
+    end # context "escaped cases"
+
+    it "should support multiple values for an option"
+
+    it "should keep parsing also when --help is passed" do
+      expect("--help a<tab>").to complete_with(%w(arg1v1 arg1v2))
+    end
+
+  end # context "with a correct configuration"
+
+  context "with an incorrect configuration" do
+
+    INCORRECT_CASES = [
+      "a b <tab>",        # too many args
+      "-O<tab>",          # no values for this option
+    ]
+
+    INCORRECT_CASES.each do |symbolic_commandline_options|
+      it "should not output any entries for #{symbolic_commandline_options.inspect}" do
+        expect(symbolic_commandline_options).to not_complete
+      end
+    end
+
+  end # context "with an incorrect configuration"
+
+end # describe SimpleScripting::TabCompletion

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,3 +49,5 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end
+
+require_relative 'helpers/tab_completion_custom_rspec_matchers'


### PR DESCRIPTION
Add the TabCompletion class, which makes trivial to define tab-completion for terminal commands.

The README contains an introduction; the full guide (wiki page) is about to be written.

Closes #38.