### PR TITLE
Improve error message for missing command

### DIFF
--- a/lib/simple_scripting/argv.rb
+++ b/lib/simple_scripting/argv.rb
@@ -89,6 +89,9 @@ module SimpleScripting
       end
 
       command = command_for_check
+
+      raise InvalidCommand.new("Missing command") if command.nil?
+
       command_params_definition = commands_definition[command]
 
       case command_params_definition

--- a/spec/simple_scripting/argv_spec.rb
+++ b/spec/simple_scripting/argv_spec.rb
@@ -270,6 +270,14 @@ describe SimpleScripting::Argv do
           expect(decoding).to raise_error(SimpleScripting::Argv::InvalidCommand, "Invalid command: pizza")
         end
 
+        it "should print a specific error message on missing command" do
+          decoder_params[:arguments] = []
+
+          decoding = -> { described_class.decode(decoder_params) }
+
+          expect(decoding).to raise_error(SimpleScripting::Argv::InvalidCommand, "Missing command")
+        end
+
       end # context "error handling"
 
       context "help" do


### PR DESCRIPTION
Change the error message from `Invalid command: ` to `Missing command`.