### PR TITLE
Support mixing mandatory arguments with varargs

### DIFF
--- a/lib/simple_scripting/argv.rb
+++ b/lib/simple_scripting/argv.rb
@@ -157,9 +157,9 @@ module SimpleScripting
       first_arg_name = arg_definitions.keys.first.to_s
 
       if first_arg_name.start_with?('*')
-        process_varargs!(arg_values, result, commands_stack, arg_definitions, parser_opts_copy)
+        process_varargs!(arg_values, result, commands_stack, arg_definitions)
       else
-        process_regular_argument!(arg_values, result, commands_stack, arg_definitions, parser_opts_copy)
+        process_regular_argument!(arg_values, result, commands_stack, arg_definitions)
       end
 
       result
@@ -191,7 +191,7 @@ module SimpleScripting
       end
     end
 
-    def process_varargs!(arg_values, result, commands_stack, arg_definitions, parser_opts_copy)
+    def process_varargs!(arg_values, result, commands_stack, arg_definitions)
       first_arg_name = arg_definitions.keys.first.to_s
 
       # Mandatory argument
@@ -211,7 +211,7 @@ module SimpleScripting
       end
     end
 
-    def process_regular_argument!(arg_values, result, commands_stack, arg_definitions, parser_opts_copy)
+    def process_regular_argument!(arg_values, result, commands_stack, arg_definitions)
       min_args_size = arg_definitions.count { |_, mandatory| mandatory }
 
       if arg_values.size < min_args_size

--- a/spec/simple_scripting/argv_spec.rb
+++ b/spec/simple_scripting/argv_spec.rb
@@ -169,28 +169,57 @@ describe SimpleScripting::Argv do
 
     describe '(mandatory)' do
 
-      let(:decoder_params) {[
-        '*varargs',
-        output:     output_buffer,
-      ]}
+      context 'as only parameter' do
 
-      it "should be decoded" do
-        decoder_params.last[:arguments] = ['varval1', 'varval2']
+        let(:decoder_params) {[
+          '*varargs',
+          output:     output_buffer,
+          arguments:  ['varval1', 'varval2'],
+        ]}
 
-        actual_result = described_class.decode(*decoder_params)
+        it "should be decoded" do
+          actual_result = described_class.decode(*decoder_params)
 
-        expected_result = {
-          varargs:   ['varval1', 'varval2'],
-        }
+          expected_result = {
+            varargs:   ['varval1', 'varval2'],
+          }
 
-        expect(actual_result).to eql(expected_result)
+          expect(actual_result).to eql(expected_result)
+        end
+
+      end
+
+      context 'followed by varargs' do
+
+        let(:decoder_params) {[
+          'mandatory',
+          '*varargs',
+          output:     output_buffer,
+          arguments:  ['mandval', 'varval1', 'varval2']
+        ]}
+
+        it "should be decoded" do
+          actual_result = described_class.decode(*decoder_params)
+
+          expected_result = {
+            mandatory: 'mandval',
+            varargs:   ['varval1', 'varval2'],
+          }
+
+          expect(actual_result).to eql(expected_result)
+        end
+
       end
 
       context "error handling" do
 
-        it "should exit when they are not specified" do
-          decoder_params.last[:arguments] = []
+        let(:decoder_params) {[
+          '*varargs',
+          output:     output_buffer,
+          arguments:  [],
+        ]}
 
+        it "should exit when they are not specified" do
           decoding = -> { described_class.decode(*decoder_params) }
 
           expect(decoding).to raise_error(SimpleScripting::Argv::ArgumentError, "Missing mandatory argument(s)")


### PR DESCRIPTION
Add support for mixing mandatory arguments with varargs, eg.:

```ruby
SimpleScripting::Argv.decode('first','*others')
```

Closes #48.