### PR TITLE
Gemfile.lock: update simple_scripting to current version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple_scripting (0.10.0)
+    simple_scripting (0.10.1)
       parseconfig (~> 1.0)
 
 GEM


### PR DESCRIPTION
The version set in Gemfile.lock (0.10.0) was not the current one (0.10.1).