### PR TITLE
Default to error printing instead of raising

### DIFF
--- a/lib/simple_scripting/argv.rb
+++ b/lib/simple_scripting/argv.rb
@@ -44,6 +44,7 @@ module SimpleScripting
       long_help = options[:long_help]
       auto_help = options.fetch(:auto_help, true)
       output    = options.fetch(:output, $stdout)
+      raise_errors = options.fetch(:raise_errors, false)
 
       # WATCH OUT! @long_help can also be set in :decode_command!. See issue #17.
       #
@@ -60,6 +61,12 @@ module SimpleScripting
       exit_data.print_help(output, @long_help)
 
       nil # to be used with the 'decode(...) || exit' pattern
+    rescue SimpleScripting::Argv::ArgumentError, SimpleScripting::Argv::InvalidCommand, OptionParser::InvalidOption => error
+      if raise_errors
+        raise
+      else
+        output.puts "Command error!: #{error.message}"
+      end
     ensure
       @long_help = nil
     end

--- a/spec/simple_scripting/argv_spec.rb
+++ b/spec/simple_scripting/argv_spec.rb
@@ -153,7 +153,7 @@ describe SimpleScripting::Argv do
         expect(decoding).to raise_error(SimpleScripting::Argv::ArgumentError, "Missing mandatory argument(s)")
       end
 
-      it "should print an error and the help when there are too many arguments" do
+      it "should raise an error when there are too many arguments" do
         decoder_params.last[:arguments] = ['arg1', 'arg2', 'excessive_arg']
 
         decoding = -> { described_class.decode(*decoder_params) }
@@ -219,7 +219,7 @@ describe SimpleScripting::Argv do
           arguments:  [],
         ]}
 
-        it "should exit when they are not specified" do
+        it "should raise an error when they are not specified" do
           decoding = -> { described_class.decode(*decoder_params) }
 
           expect(decoding).to raise_error(SimpleScripting::Argv::ArgumentError, "Missing mandatory argument(s)")


### PR DESCRIPTION
In commandline context, stack traces should not be printed for invalid commands, since it's confusing.

This PR defaults the behavior to printing the error message, with a prefix, to the output ($stdout by default).