### PR TITLE
Configuration: add support for required keys

### DIFF
--- a/spec/simple_scripting/configuration_spec.rb
+++ b/spec/simple_scripting/configuration_spec.rb
@@ -54,6 +54,14 @@ g2_key=bang
     end
   end
 
+  it "should raise an error when required keys are missing" do
+    with_tempfile(configuration_text) do |config_file|
+      error_call = -> { described_class.load(config_file: config_file, required: %w(abspath_key missing_key group1)) }
+
+      expect(error_call).to raise_error(RuntimeError, "Missing required configuration key(s): missing_key, group1")
+    end
+  end
+
   it "should create the configuration file if it doesn't exist" do
     temp_config_file = File.join(Dir.tmpdir, '.test_simple_scripting_config')
 


### PR DESCRIPTION
This allows the caller to specify keys that are required in the configuration, avoiding direct checks.

The current functionality is basic: it supports only keys outside a group.