### PR TITLE
Implement automatic array decoding for switch arguments

### DIFF
--- a/lib/simple_scripting/argv.rb
+++ b/lib/simple_scripting/argv.rb
@@ -210,8 +210,18 @@ module SimpleScripting
     # DEFINITIONS PROCESSING ###############################
 
     def process_option_definition!(param_definition, parser_opts, result)
+      # Work on a copy; in at least one case (data type definition), we perform destructive
+      # operations.
+      #
+      param_definition = param_definition.dup
+
       if param_definition[1] && param_definition[1].start_with?('--')
-        key = param_definition[1].split(' ')[0][2 .. -1].tr('-', '_').to_sym
+        raw_key, key_argument = param_definition[1].split(' ')
+        key = raw_key[2 .. -1].tr('-', '_').to_sym
+
+        if key_argument&.include?(',')
+          param_definition.insert(2, Array)
+        end
       else
         key = param_definition[0][1 .. -1].to_sym
       end

--- a/spec/simple_scripting/argv_spec.rb
+++ b/spec/simple_scripting/argv_spec.rb
@@ -13,7 +13,7 @@ describe SimpleScripting::Argv do
     let(:decoder_params) {[
       ['-a'                                        ],
       ['-b',                     '"-b" description'],
-      ['-c', '--c-switch'                          ],
+      ['-c', '--c-switch VAL1,VAL2'                ],
       ['-d', '--d-switch',       '"-d" description'],
       ['-e', '--e-switch VALUE'                    ],
       ['-f', '--f-switch VALUE', '"-f" description'],
@@ -34,7 +34,7 @@ describe SimpleScripting::Argv do
           Usage: rspec [options] <mandatory> [<optional>]
               -a
               -b                               "-b" description
-              -c, --c-switch
+              -c, --c-switch VAL1,VAL2
               -d, --d-switch                   "-d" description
               -e, --e-switch VALUE
               -f, --f-switch VALUE             "-f" description
@@ -78,15 +78,15 @@ describe SimpleScripting::Argv do
 
     end # context 'help'
 
-    it "should implement basic switches and arguments (all set)" do
-      decoder_params.last[:arguments] = ['-a', '-b', '-c', '-d', '-ev_swt', '-fv_swt', 'm_arg', 'o_arg']
+    it "should implement basic switches, with conversion, and arguments (all set)" do
+      decoder_params.last[:arguments] = ['-a', '-b', '-c', 'a,b,c', '-d', '-ev_swt', '-fv_swt', 'm_arg', 'o_arg']
 
       actual_result = described_class.decode(*decoder_params)
 
       expected_result = {
         a:          true,
         b:          true,
-        c_switch:   true,
+        c_switch:   %w(a b c),
         d_switch:   true,
         e_switch:   'v_swt',
         f_switch:   'v_swt',


### PR DESCRIPTION
Allow automatic decoding to array, when an argument defition switch includes commas, like:

```
--myargument VAL1,VAL2
```

Closes #55.